### PR TITLE
Added "auth0-lock", "jwt-decode" and "react-router"(v3) to package.json

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -69,9 +69,12 @@
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {
+    "auth0-lock": "^11.10.0",
     "bundle-deps": "1.0.0",
+    "jwt-decode": "^2.2.0",
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "react-router": "^3.2.1"
   },
   "optionalDependencies": {
     "fsevents": "1.0.14"


### PR DESCRIPTION
Fixes the following `npm start` errors:
```
Module not found: 'react-router'
Module not found: 'jwt-decode'
Module not found: 'auth0-lock'
```